### PR TITLE
Preventing "auto-supporting" a campaign when you sign in on CampaignDetailsPage. Added sign_in_start_full_url set cookie when you sign in so Twitter sign in takes you back to the campaign.

### DIFF
--- a/src/js/actions/AppActions.js
+++ b/src/js/actions/AppActions.js
@@ -11,6 +11,10 @@ export default {
     Dispatcher.dispatch({ type: 'activityTidbitWeVoteIdForDrawerAndOpen', payload: activityTidbitWeVoteId });
   },
 
+  setBlockCampaignXRedirectOnSignIn (value) {
+    Dispatcher.dispatch({ type: 'blockCampaignXRedirectOnSignIn', payload: value });
+  },
+
   setCampaignFirstRetrieveInitiated (value) {
     Dispatcher.dispatch({ type: 'campaignFirstRetrieveInitiated', payload: value });
   },

--- a/src/js/components/CampaignSupport/MostRecentCampaignSupport.jsx
+++ b/src/js/components/CampaignSupport/MostRecentCampaignSupport.jsx
@@ -266,6 +266,7 @@ const CommentVoterPhotoWrapper = styled.div`
   align-items: flex-start;
   display: flex;
   margin-right: 6px;
+  width: 24px;
 `;
 
 const CommentWrapper = styled.div`

--- a/src/js/components/CampaignSupport/SupportButton.jsx
+++ b/src/js/components/CampaignSupport/SupportButton.jsx
@@ -76,6 +76,7 @@ class SupportButton extends Component {
       AppActions.setShowCompleteYourProfileModal(true);
     } else {
       // Mark that voter supports this campaign
+      AppActions.setBlockCampaignXRedirectOnSignIn(false);
       this.props.functionToUseWhenProfileComplete();
     }
   }

--- a/src/js/components/CampaignSupport/SupportButtonBeforeCompletionScreen.jsx
+++ b/src/js/components/CampaignSupport/SupportButtonBeforeCompletionScreen.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Button } from '@material-ui/core';
 import { withStyles, withTheme } from '@material-ui/core/styles';
 import styled from 'styled-components';
+import AppActions from '../../actions/AppActions';
 import CampaignStore from '../../stores/CampaignStore';
 import CampaignSupporterStore from '../../stores/CampaignSupporterStore';
 import { historyPush } from '../../utils/cordovaUtils';
@@ -150,6 +151,7 @@ class SupportButtonBeforeCompletionScreen extends Component {
       }
     } else {
       // Mark that voter supports this campaign
+      AppActions.setBlockCampaignXRedirectOnSignIn(false);
       this.props.functionToUseWhenProfileComplete();
     }
   }

--- a/src/js/components/Navigation/SignInButton.jsx
+++ b/src/js/components/Navigation/SignInButton.jsx
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import cookies from '../../utils/cookies';
 import AppActions from '../../actions/AppActions';
 import voterSignOut from '../../utils/voterSignOut';
 import VoterStore from '../../stores/VoterStore';
 import { renderLog } from '../../utils/logging';
+import { stringContains } from '../../utils/textFormat';
 
 
 class SignInButton extends Component {
@@ -33,8 +35,18 @@ class SignInButton extends Component {
   }
 
   openSignInModal = () => {
-    // console.log('openSignInModal');
+    // console.log('SignInButton openSignInModal');
+    const { origin, pathname } = window.location;
+    const signInStartFullUrl = `${origin}${pathname}`;
+    const oneDayExpires = 86400;
+    // console.log('SettingsAccount getStartedForCampaigns, new origin: ', origin, ', pathname: ', pathname, ', signInStartFullUrl: ', signInStartFullUrl);
+    if (origin && stringContains('wevote.us', origin)) {
+      cookies.setItem('sign_in_start_full_url', signInStartFullUrl, oneDayExpires, '/', 'wevote.us');
+    } else {
+      cookies.setItem('sign_in_start_full_url', signInStartFullUrl, oneDayExpires, '/');
+    }
     AppActions.setShowSignInModal(true);
+    AppActions.setBlockCampaignXRedirectOnSignIn(true);
   };
 
   signOut = () => {

--- a/src/js/components/Settings/CompleteYourProfile.jsx
+++ b/src/js/components/Settings/CompleteYourProfile.jsx
@@ -188,10 +188,12 @@ class CompleteYourProfile extends Component {
       });
     } else if (!voterIsSignedInWithEmail) {
       // All required fields were found
+      AppActions.setBlockCampaignXRedirectOnSignIn(false);
       this.sendSignInCodeEmail(event, voterEmailQueuedToSave);
     } else {
       VoterActions.voterRetrieve();
       this.functionToUseWhenProfileCompleteTimer = setTimeout(() => {
+        AppActions.setBlockCampaignXRedirectOnSignIn(false);
         this.props.functionToUseWhenProfileComplete();
       }, 500);
     }

--- a/src/js/components/Settings/CompleteYourProfileModalController.jsx
+++ b/src/js/components/Settings/CompleteYourProfileModalController.jsx
@@ -33,6 +33,7 @@ class CompleteYourProfileModalController extends Component {
   }
 
   closeModal () {
+    // console.log('CompleteYourProfileModalController closeModal');
     AppActions.setShowCompleteYourProfileModal(false);
   }
 

--- a/src/js/components/Settings/SettingsAccount.jsx
+++ b/src/js/components/Settings/SettingsAccount.jsx
@@ -96,7 +96,11 @@ export default class SettingsAccount extends Component {
         pathname = '/settings/profile';
         signInStartFullUrl = `${origin}${pathname}`;
         // console.log('SettingsAccount getStartedForCampaigns, new origin: ', origin, ', pathname: ', pathname, ', signInStartFullUrl: ', signInStartFullUrl);
-        cookies.setItem('sign_in_start_full_url', signInStartFullUrl, oneDayExpires, '/', 'wevote.us');
+        if (origin && stringContains('wevote.us', origin)) {
+          cookies.setItem('sign_in_start_full_url', signInStartFullUrl, oneDayExpires, '/', 'wevote.us');
+        } else {
+          cookies.setItem('sign_in_start_full_url', signInStartFullUrl, oneDayExpires, '/');
+        }
         this.setState({
           pleaseSignInTitle: 'Please sign in to get started.',
           pleaseSignInSubTitle: 'Use Twitter to verify your account most quickly.',
@@ -105,7 +109,11 @@ export default class SettingsAccount extends Component {
         pathname = '/settings/profile';
         signInStartFullUrl = `${origin}${pathname}`;
         // console.log('SettingsAccount getStartedForCampaigns, new origin: ', origin, ', pathname: ', pathname, ', signInStartFullUrl: ', signInStartFullUrl);
-        cookies.setItem('sign_in_start_full_url', signInStartFullUrl, oneDayExpires, '/', 'wevote.us');
+        if (origin && stringContains('wevote.us', origin)) {
+          cookies.setItem('sign_in_start_full_url', signInStartFullUrl, oneDayExpires, '/', 'wevote.us');
+        } else {
+          cookies.setItem('sign_in_start_full_url', signInStartFullUrl, oneDayExpires, '/');
+        }
         this.setState({
           pleaseSignInTitle: 'Please sign in to get started.',
           pleaseSignInSubTitle: 'Use Twitter to verify your account most quickly.',
@@ -114,7 +122,11 @@ export default class SettingsAccount extends Component {
         pathname = '/settings/profile';
         signInStartFullUrl = `${origin}${pathname}`;
         // console.log('SettingsAccount getStartedForCampaigns, new origin: ', origin, ', pathname: ', pathname, ', signInStartFullUrl: ', signInStartFullUrl);
-        cookies.setItem('sign_in_start_full_url', signInStartFullUrl, oneDayExpires, '/', 'wevote.us');
+        if (origin && stringContains('wevote.us', origin)) {
+          cookies.setItem('sign_in_start_full_url', signInStartFullUrl, oneDayExpires, '/', 'wevote.us');
+        } else {
+          cookies.setItem('sign_in_start_full_url', signInStartFullUrl, oneDayExpires, '/');
+        }
         this.setState({
           pleaseSignInTitle: 'Please sign in to get started.',
           pleaseSignInSubTitle: 'Don\'t worry, we won\'t post anything automatically.',

--- a/src/js/components/Settings/VoterPhotoUpload.jsx
+++ b/src/js/components/Settings/VoterPhotoUpload.jsx
@@ -135,6 +135,8 @@ const styles = (theme) => ({
     fontSize: '18px',
     fontFamily: "'Nunito Sans', 'Helvetica Neue Light', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif",
     fontWeight: '300',
+    paddingLeft: 5,
+    paddingRight: 5,
   },
 });
 

--- a/src/js/pages/CampaignDetailsPage.jsx
+++ b/src/js/pages/CampaignDetailsPage.jsx
@@ -195,11 +195,13 @@ class CampaignDetailsPage extends Component {
       // If it has changed, use new value
       visibleToPublic = CampaignSupporterStore.getVisibleToPublicQueuedToSave();
     }
-    // console.log('functionToUseWhenProfileComplete, visibleToPublic:', visibleToPublic, ', visibleToPublicChanged:', visibleToPublicChanged);
+    // console.log('functionToUseWhenProfileComplete, visibleToPublic:', visibleToPublic, ', visibleToPublicChanged:', visibleToPublicChanged, ', blockCampaignXRedirectOnSignIn:', AppStore.blockCampaignXRedirectOnSignIn());
     const saveVisibleToPublic = true;
-    initializejQuery(() => {
-      CampaignSupporterActions.supportCampaignSave(campaignXWeVoteId, campaignSupported, campaignSupportedChanged, visibleToPublic, saveVisibleToPublic);
-    }, this.goToNextPage());
+    if (!AppStore.blockCampaignXRedirectOnSignIn()) {
+      initializejQuery(() => {
+        CampaignSupporterActions.supportCampaignSave(campaignXWeVoteId, campaignSupported, campaignSupportedChanged, visibleToPublic, saveVisibleToPublic);
+      }, this.goToNextPage());
+    }
   }
 
   onCampaignEditClick = () => {

--- a/src/js/stores/AppStore.js
+++ b/src/js/stores/AppStore.js
@@ -13,6 +13,7 @@ class AppStore extends ReduceStore {
   getInitialState () {
     return {
       activityTidbitWeVoteIdForDrawer: '',
+      blockCampaignXRedirectOnSignIn: false, // When signing in from the header, don't mark a campaign as supported
       campaignFirstRetrieveInitiated: false,
       campaignListFirstRetrieveInitiated: false,
       chosenPreventSharingOpinions: false,
@@ -57,6 +58,10 @@ class AppStore extends ReduceStore {
 
   activityTidbitWeVoteIdForDrawer () {
     return this.getState().activityTidbitWeVoteIdForDrawer;
+  }
+
+  blockCampaignXRedirectOnSignIn () {
+    return this.getState().blockCampaignXRedirectOnSignIn;
   }
 
   campaignFirstRetrieveInitiated () {
@@ -309,6 +314,8 @@ class AppStore extends ReduceStore {
           activityTidbitWeVoteIdForDrawer: action.payload,
           showActivityTidbitDrawer: true,
         };
+      case 'blockCampaignXRedirectOnSignIn':
+        return { ...state, blockCampaignXRedirectOnSignIn: action.payload };
       case 'campaignFirstRetrieveInitiated':
         return { ...state, campaignFirstRetrieveInitiated: action.payload };
       case 'campaignListFirstRetrieveInitiated':


### PR DESCRIPTION
Preventing "auto-supporting" a campaign when you sign in on CampaignDetailsPage. Added sign_in_start_full_url set cookie when you sign in so Twitter sign in takes you back to the campaign.