### PR TITLE
Campaign owners can now delete campaign photos before adding a new one. Moved LazyImage component into common/components folder (also updating WebApp).

### DIFF
--- a/src/js/actions/CampaignStartActions.js
+++ b/src/js/actions/CampaignStartActions.js
@@ -22,7 +22,9 @@ export default {
   campaignEditAllSave (
     campaignXWeVoteId,
     campaignDescriptionQueuedToSave, campaignDescriptionQueuedToSaveSet,
-    campaignPhotoQueuedToSave, campaignPhotoQueuedToSaveSet, campaignPoliticianDeleteListJson,
+    campaignPhotoQueuedToDelete, campaignPhotoQueuedToDeleteSet,
+    campaignPhotoQueuedToSave, campaignPhotoQueuedToSaveSet,
+    campaignPoliticianDeleteListJson,
     campaignPoliticianStarterListQueuedToSave, campaignPoliticianStarterListQueuedToSaveSet,
     campaignTitleQueuedToSave, campaignTitleQueuedToSaveSet,
   ) {
@@ -32,6 +34,8 @@ export default {
         campaign_description_changed: campaignDescriptionQueuedToSaveSet,
         campaign_photo_from_file_reader: campaignPhotoQueuedToSave,
         campaign_photo_changed: campaignPhotoQueuedToSaveSet,
+        campaign_photo_delete: campaignPhotoQueuedToDelete,
+        campaign_photo_delete_changed: campaignPhotoQueuedToDeleteSet,
         campaign_title: campaignTitleQueuedToSave,
         campaign_title_changed: campaignTitleQueuedToSaveSet,
         campaignx_we_vote_id: campaignXWeVoteId,
@@ -39,6 +43,10 @@ export default {
         politician_starter_list: campaignPoliticianStarterListQueuedToSave,
         politician_starter_list_changed: campaignPoliticianStarterListQueuedToSaveSet,
       });
+  },
+
+  campaignPhotoQueuedToDelete (deleteCampaignPhoto = true) {
+    Dispatcher.dispatch({ type: 'campaignPhotoQueuedToDelete', payload: deleteCampaignPhoto });
   },
 
   campaignPhotoQueuedToSave (campaignPhotoFromFileReader) {

--- a/src/js/common/components/LazyImage.jsx
+++ b/src/js/common/components/LazyImage.jsx
@@ -13,13 +13,18 @@ export default class LazyImage extends React.Component {
     const { src } = this.props;
     // console.log('LazyImage componentDidMount props:', this.props);
 
-    const imageLoader = new Image();
-    imageLoader.src = src;
+    this.imageLoader = new Image();
+    this.imageLoader.src = src;
 
-    imageLoader.onload = () => {
+    this.imageLoader.onload = () => {
       // console.log('LazyImage loaded src:', src);
       this.setState({ src });
     };
+  }
+
+  componentWillUnmount () {
+    this.imageLoader.onload = () => {};
+    this.imageLoader = null;
   }
 
   render () {

--- a/src/js/components/Campaign/CampaignCommentForList.jsx
+++ b/src/js/components/Campaign/CampaignCommentForList.jsx
@@ -9,7 +9,7 @@ import anonymous from '../../../img/global/icons/avatar-generic.png';
 import CampaignStore from '../../stores/CampaignStore';
 import CampaignSupporterStore from '../../stores/CampaignSupporterStore';
 import { isCordova } from '../../utils/cordovaUtils';
-import LazyImage from '../../utils/LazyImage';
+import LazyImage from '../../common/components/LazyImage';
 import { renderLog } from '../../utils/logging';
 import { timeFromDate } from '../../utils/dateFormat';
 import { stringContains } from '../../utils/textFormat';

--- a/src/js/components/Campaign/CampaignNewsItemForList.jsx
+++ b/src/js/components/Campaign/CampaignNewsItemForList.jsx
@@ -11,7 +11,7 @@ import {
 } from '../Style/CampaignIndicatorStyles';
 import CampaignStore from '../../stores/CampaignStore';
 import { historyPush, isCordova } from '../../utils/cordovaUtils';
-import LazyImage from '../../utils/LazyImage';
+import LazyImage from '../../common/components/LazyImage';
 import { renderLog } from '../../utils/logging';
 import { timeFromDate } from '../../utils/dateFormat';
 import { stringContains } from '../../utils/textFormat';

--- a/src/js/components/CampaignStart/CampaignPhotoUpload.jsx
+++ b/src/js/components/CampaignStart/CampaignPhotoUpload.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Button } from '@material-ui/core';
 import { DropzoneArea } from 'material-ui-dropzone';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -54,6 +55,10 @@ class CampaignPhotoUpload extends Component {
     this.campaignStartStoreListener.remove();
     this.campaignStoreListener.remove();
     // TODO Figure out how to add fileReader.removeEventListener
+    // if (this.fileReader) {
+    //   this.fileReader.removeEventListener('load', this.cachePhotoFromFileReader, false);
+    //   this.fileReader = null;
+    // }
   }
 
   handleDrop (files) {
@@ -67,6 +72,15 @@ class CampaignPhotoUpload extends Component {
         CampaignStartActions.campaignPhotoQueuedToSave(photoFromFileReader);
       });
       fileReader.readAsDataURL(fileFromDropzone);
+      // An attempt at figuring out how to removeEventListener
+      // this.fileReader = new FileReader();
+      // this.fileReader.addEventListener('load', () => {
+      //   const photoFromFileReader = this.fileReader.result;
+      //   // console.log('photoFromFileReader:', photoFromFileReader);
+      //   CampaignStartActions.campaignPhotoQueuedToSave(photoFromFileReader);
+      // });
+      // this.fileReader.addEventListener('load', () => this.cachePhotoFromFileReader);
+      // this.fileReader.readAsDataURL(fileFromDropzone);
     }
   }
 
@@ -81,42 +95,81 @@ class CampaignPhotoUpload extends Component {
     } else {
       campaignPhotoLargeUrl = CampaignStartStore.getCampaignPhotoLargeUrl();
     }
+    const campaignPhotoQueuedToDelete = CampaignStartStore.getCampaignPhotoQueuedToDelete();
+    const campaignPhotoQueuedToDeleteSet = CampaignStartStore.getCampaignPhotoQueuedToDeleteSet();
     this.setState({
       campaignPhotoLargeUrl,
+      campaignPhotoQueuedToDelete,
+      campaignPhotoQueuedToDeleteSet,
     });
+  }
+
+  // cachePhotoFromFileReader = () => {
+  //   const photoFromFileReader = this.fileReader.result;
+  //   // console.log('photoFromFileReader:', photoFromFileReader);
+  //   CampaignStartActions.campaignPhotoQueuedToSave(photoFromFileReader);
+  //   return true;
+  // }
+
+  markCampaignImageForDelete = () => {
+    CampaignStartActions.campaignPhotoQueuedToDelete(true);
   }
 
   render () {
     renderLog('CampaignPhotoUpload');  // Set LOG_RENDER_EVENTS to log all renders
 
     const { classes } = this.props;
-    const { campaignPhotoLargeUrl } = this.state;
+    const { campaignPhotoLargeUrl, campaignPhotoQueuedToDelete, campaignPhotoQueuedToDeleteSet } = this.state;
+    let campaignPhotoExists = false;
     let dropzoneText = isMobileScreenSize() ? 'Upload campaign photo' : 'Drag campaign photo here (or click to find file)';
     if (campaignPhotoLargeUrl) {
+      campaignPhotoExists = true;
       dropzoneText = isMobileScreenSize() ? 'Upload new photo' : 'Drag new photo here (or click to find file)';
     }
+    const campaignPhotoMarkedForDeletion = Boolean(campaignPhotoQueuedToDelete && campaignPhotoQueuedToDeleteSet);
+    // console.log('campaignPhotoMarkedForDeletion:', campaignPhotoMarkedForDeletion);
     return (
       <div className="">
         <form onSubmit={(e) => { e.preventDefault(); }}>
           <Wrapper>
             <ColumnFullWidth>
-              {campaignPhotoLargeUrl && (
-                <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+              {(campaignPhotoExists && !campaignPhotoMarkedForDeletion) ? (
+                <OverlayOuterWrapper>
+                  <OverlayInnerWrapper>
+                    <CampaignImageDeleteButtonOuterWrapper>
+                      <CampaignImageDeleteButtonInnerWrapper>
+                        <Button
+                          classes={{ root: classes.buttonDelete }}
+                          color="primary"
+                          id="deleteCurrent Image"
+                          onClick={this.markCampaignImageForDelete}
+                          variant="contained"
+                        >
+                          Delete
+                        </Button>
+                      </CampaignImageDeleteButtonInnerWrapper>
+                    </CampaignImageDeleteButtonOuterWrapper>
+                    <CampaignImageWrapper>
+                      <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                    </CampaignImageWrapper>
+                  </OverlayInnerWrapper>
+                </OverlayOuterWrapper>
+              ) : (
+                <MuiThemeProvider theme={muiTheme}>
+                  <DropzoneArea
+                    acceptedFiles={['image/*']}
+                    classes={{
+                      icon: classes.dropzoneIcon,
+                      root: classes.dropzoneRoot,
+                    }}
+                    dropzoneText={dropzoneText}
+                    filesLimit={1}
+                    initialFiles={campaignPhotoExists ? [campaignPhotoLargeUrl] : undefined}
+                    maxFileSize={6000000}
+                    onChange={this.handleDrop}
+                  />
+                </MuiThemeProvider>
               )}
-              <MuiThemeProvider theme={muiTheme}>
-                <DropzoneArea
-                  acceptedFiles={['image/*']}
-                  classes={{
-                    icon: classes.dropzoneIcon,
-                    root: classes.dropzoneRoot,
-                  }}
-                  dropzoneText={dropzoneText}
-                  filesLimit={1}
-                  initialFiles={campaignPhotoLargeUrl ? [campaignPhotoLargeUrl] : undefined}
-                  maxFileSize={6000000}
-                  onChange={this.handleDrop}
-                />
-              </MuiThemeProvider>
             </ColumnFullWidth>
           </Wrapper>
         </form>
@@ -131,6 +184,19 @@ CampaignPhotoUpload.propTypes = {
 };
 
 const styles = (theme) => ({
+  buttonDelete: {
+    backgroundColor: '#f44336',
+    boxShadow: 'none !important',
+    fontSize: '18px',
+    height: '35px !important',
+    '&:hover': {
+      backgroundColor: '#8C001A',
+    },
+    marginLeft: 10,
+    padding: '0 30px',
+    textTransform: 'none',
+    width: 100,
+  },
   dropzoneIcon: {
     color: '#999',
   },
@@ -146,8 +212,38 @@ const CampaignImage = styled.img`
   width: 100%;
 `;
 
+const CampaignImageWrapper = styled.div`
+  margin-top: ${({ ipad }) => (ipad ? '-11px' : '-44px')};
+`;
+
+const CampaignImageDeleteButtonOuterWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  position: relative;
+  z-index: 1;
+  transform: ${({ ipad }) => (ipad ? 'translate(0%, 100%)' : '')}
+`;
+
+const CampaignImageDeleteButtonInnerWrapper = styled.div`
+  margin-right: 8px;
+  z-index: 2;
+`;
+
 const ColumnFullWidth = styled.div`
   padding: 8px 12px;
+  width: 100%;
+`;
+
+const OverlayOuterWrapper = styled.div`
+  align-self: flex-end;
+  // width: 640px;
+  display: flex;
+  // padding: 0 15px;
+`;
+
+const OverlayInnerWrapper = styled.div`
+  min-height: 37px;
   width: 100%;
 `;
 
@@ -155,6 +251,7 @@ const Wrapper = styled.div`
   display: flex;
   justify-content: space-between;
   margin-left: -12px;
+  margin-top: 10px;
   width: calc(100% + 24px);
 `;
 

--- a/src/js/components/CampaignSupport/MostRecentCampaignSupport.jsx
+++ b/src/js/components/CampaignSupport/MostRecentCampaignSupport.jsx
@@ -6,7 +6,7 @@ import { withStyles } from '@material-ui/core/styles';
 import anonymous from '../../../img/global/icons/avatar-generic.png';
 import CampaignSupporterStore from '../../stores/CampaignSupporterStore';
 import CampaignStore from '../../stores/CampaignStore';
-import LazyImage from '../../utils/LazyImage';
+import LazyImage from '../../common/components/LazyImage';
 import { renderLog } from '../../utils/logging';
 import returnFirstXWords from '../../utils/returnFirstXWords';
 import { timeFromDate } from '../../utils/dateFormat';

--- a/src/js/components/Navigation/VoterNameAndPhoto.jsx
+++ b/src/js/components/Navigation/VoterNameAndPhoto.jsx
@@ -5,7 +5,7 @@ import MenuIcon from '@material-ui/icons/Menu';
 import { withStyles } from '@material-ui/core/styles';
 import styled from 'styled-components';
 import avatarGeneric from '../../../img/global/icons/avatar-generic.png';
-import LazyImage from '../../utils/LazyImage';
+import LazyImage from '../../common/components/LazyImage';
 import { renderLog } from '../../utils/logging';
 import { shortenText } from '../../utils/textFormat';
 import VoterStore from '../../stores/VoterStore';

--- a/src/js/pages/CampaignNewsItemDetailsPage.jsx
+++ b/src/js/pages/CampaignNewsItemDetailsPage.jsx
@@ -27,7 +27,7 @@ import keepHelpingDestination from '../utils/keepHelpingDestination';
 import OpenExternalWebSite from '../components/Widgets/OpenExternalWebSite';
 import { renderLog } from '../utils/logging';
 import returnFirstXWords from '../utils/returnFirstXWords';
-import LazyImage from '../utils/LazyImage';
+import LazyImage from '../common/components/LazyImage';
 import anonymous from '../../img/global/icons/avatar-generic.png';
 import { stringContains } from '../utils/textFormat';
 

--- a/src/js/pages/CampaignStart/CampaignStartEditAll.jsx
+++ b/src/js/pages/CampaignStart/CampaignStartEditAll.jsx
@@ -155,6 +155,7 @@ class CampaignStartEditAll extends Component {
   cancelEditAll = () => {
     const { editExistingCampaign } = this.props;
     if (editExistingCampaign) {
+      CampaignStartActions.campaignEditAllReset();
       const { campaignXWeVoteId, campaignSEOFriendlyPath } = this.state;
       if (campaignSEOFriendlyPath) {
         historyPush(`/c/${campaignSEOFriendlyPath}`);
@@ -171,6 +172,8 @@ class CampaignStartEditAll extends Component {
     const { campaignXWeVoteId, voterIsCampaignXOwner } = this.state;
     const campaignDescriptionQueuedToSave = CampaignStartStore.getCampaignDescriptionQueuedToSave();
     const campaignDescriptionQueuedToSaveSet = CampaignStartStore.getCampaignDescriptionQueuedToSaveSet();
+    const campaignPhotoQueuedToDelete = CampaignStartStore.getCampaignPhotoQueuedToDelete();
+    const campaignPhotoQueuedToDeleteSet = CampaignStartStore.getCampaignPhotoQueuedToDeleteSet();
     const campaignPhotoQueuedToSave = CampaignStartStore.getCampaignPhotoQueuedToSave();
     const campaignPhotoQueuedToSaveSet = CampaignStartStore.getCampaignPhotoQueuedToSaveSet();
     const campaignPoliticianDeleteList = CampaignStartStore.getCampaignPoliticianDeleteList();
@@ -179,14 +182,16 @@ class CampaignStartEditAll extends Component {
     const campaignTitleQueuedToSave = CampaignStartStore.getCampaignTitleQueuedToSave();
     const campaignTitleQueuedToSaveSet = CampaignStartStore.getCampaignTitleQueuedToSaveSet();
     // console.log('CampaignStartEditAll campaignPoliticianStarterListQueuedToSaveSet:', campaignPoliticianStarterListQueuedToSaveSet);
-    if (voterIsCampaignXOwner && (campaignDescriptionQueuedToSaveSet || campaignPhotoQueuedToSaveSet || campaignPoliticianDeleteList || campaignPoliticianStarterListQueuedToSaveSet || campaignTitleQueuedToSaveSet)) {
+    if (voterIsCampaignXOwner && (campaignDescriptionQueuedToSaveSet || campaignPhotoQueuedToDeleteSet || campaignPhotoQueuedToSaveSet || campaignPoliticianDeleteList || campaignPoliticianStarterListQueuedToSaveSet || campaignTitleQueuedToSaveSet)) {
       const campaignPoliticianDeleteListJson = JSON.stringify(campaignPoliticianDeleteList);
       const campaignPoliticianStarterListQueuedToSaveJson = JSON.stringify(campaignPoliticianStarterListQueuedToSave);
       // console.log('CampaignStartEditAll campaignPoliticianStarterListQueuedToSaveJson:', campaignPoliticianStarterListQueuedToSaveJson);
       CampaignStartActions.campaignEditAllSave(
         campaignXWeVoteId,
         campaignDescriptionQueuedToSave, campaignDescriptionQueuedToSaveSet,
-        campaignPhotoQueuedToSave, campaignPhotoQueuedToSaveSet, campaignPoliticianDeleteListJson,
+        campaignPhotoQueuedToDelete, campaignPhotoQueuedToDeleteSet,
+        campaignPhotoQueuedToSave, campaignPhotoQueuedToSaveSet,
+        campaignPoliticianDeleteListJson,
         campaignPoliticianStarterListQueuedToSaveJson, campaignPoliticianStarterListQueuedToSaveSet,
         campaignTitleQueuedToSave, campaignTitleQueuedToSaveSet,
       );
@@ -291,7 +296,7 @@ class CampaignStartEditAll extends Component {
                       editExistingCampaign={editExistingCampaign}
                     />
                     <PhotoUploadWrapper>
-                      Try to upload a photo that is 1200 x 628 pixels or larger. We can accept one photo up to 5 megabytes in size.
+                      We recommend you use a photo that is 1200 x 628 pixels or larger. We can accept one photo up to 5 megabytes in size.
                       <CampaignPhotoUpload
                         campaignXWeVoteId={campaignXWeVoteId}
                         editExistingCampaign={editExistingCampaign}
@@ -392,18 +397,21 @@ const SaveCancelInnerWrapper = styled.div`
 const SaveCancelOuterWrapper = styled.div`
   background-color: #f6f4f6;
   border-bottom: 1px solid #ddd;
-  // margin: 10px 0;
+  margin-top: 0;
+  position: fixed;
   width: 100%;
+  z-index: 2;
 `;
 
 const InnerWrapper = styled.div`
+  margin-top: 75px;
   width: 100%;
 `;
 
 const OuterWrapper = styled.div`
   display: flex;
   justify-content: center;
-  margin: 15px 0;
+  margin: 0;
 `;
 
 const PageWrapper = styled.div`

--- a/src/js/stores/CampaignStartStore.js
+++ b/src/js/stores/CampaignStartStore.js
@@ -8,6 +8,8 @@ class CampaignStartStore extends ReduceStore {
       campaignDescriptionQueuedToSave: '',
       campaignDescriptionQueuedToSaveSet: false,
       campaignPhotoLargeUrl: '',
+      campaignPhotoQueuedToDelete: false,
+      campaignPhotoQueuedToDeleteSet: false,
       campaignPhotoQueuedToSave: '',
       campaignPhotoQueuedToSaveSet: false,
       campaignPoliticianDeleteList: [],
@@ -85,6 +87,14 @@ class CampaignStartStore extends ReduceStore {
     return this.getState().campaignPhotoLargeUrl || '';
   }
 
+  getCampaignPhotoQueuedToDelete () {
+    return this.getState().campaignPhotoQueuedToDelete;
+  }
+
+  getCampaignPhotoQueuedToDeleteSet () {
+    return this.getState().campaignPhotoQueuedToDeleteSet;
+  }
+
   getCampaignPhotoQueuedToSave () {
     return this.getState().campaignPhotoQueuedToSave;
   }
@@ -158,6 +168,8 @@ class CampaignStartStore extends ReduceStore {
           ...state,
           campaignDescriptionQueuedToSave: '',
           campaignDescriptionQueuedToSaveSet: false,
+          campaignPhotoQueuedToDelete: false,
+          campaignPhotoQueuedToDeleteSet: false,
           campaignPhotoQueuedToSave: '',
           campaignPhotoQueuedToSaveSet: false,
           campaignPoliticianStarterListQueuedToSave: [],
@@ -165,6 +177,22 @@ class CampaignStartStore extends ReduceStore {
           campaignTitleQueuedToSave: '',
           campaignTitleQueuedToSaveSet: false,
         };
+
+      case 'campaignPhotoQueuedToDelete':
+        console.log('CampaignStartStore campaignPhotoQueuedToDelete: ', action.payload);
+        if (action.payload === undefined) {
+          return {
+            ...state,
+            campaignPhotoQueuedToDelete: false,
+            campaignPhotoQueuedToDeleteSet: false,
+          };
+        } else {
+          return {
+            ...state,
+            campaignPhotoQueuedToDelete: action.payload,
+            campaignPhotoQueuedToDeleteSet: true,
+          };
+        }
 
       case 'campaignPhotoQueuedToSave':
         // console.log('CampaignStartStore campaignPhotoQueuedToSave: ', action.payload);


### PR DESCRIPTION
Campaign owners can now delete campaign photos before adding a new one. Moved LazyImage component into common/components folder (also updating WebApp).