### PR TITLE
Configured all TruncateMarkup instances to do line breaks at the end of words instead of in the middle. Added "Read less" to mirror "Read more". Sorting news items and comments to show most recent at the top. Removed We Vote logo sharing image, since it takes away from Campaign message.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -16,9 +16,8 @@
     <meta charset="utf-8">
     <meta property="og:url"           content="https://campaigns.WeVote.US" />
     <meta property="og:type"          content="website" />
-    <meta property="og:title"         content="WeVote.US Campaigns" />
+    <meta property="og:title"         content="Support this campaign" />
     <meta property="og:description"   content="Vote for candidates you like. Oppose candidates you don't." />
-    <meta property="og:image"         content="/img/global/logos/we-vote-logo-wordmark-vertical-color-on-white-256x256.png" />
     <base href="/">
     <!-- NOTE: if testing local changes to main.css, change the following href to  "/css/main.css"   -->
     <link href="/css/main.css" rel="stylesheet" type="text/css" />

--- a/src/js/components/Campaign/CampaignCardForList.jsx
+++ b/src/js/components/Campaign/CampaignCardForList.jsx
@@ -351,13 +351,14 @@ class CampaignCardForList extends Component {
                 </SupportersWrapper>
                 <OneCampaignDescription>
                   <TruncateMarkup
-                    lines={4}
                     ellipsis={(
                       <span>
                         <span className="u-text-fade-at-end">&nbsp;</span>
                         <span className="u-link-color u-link-underline">Read more</span>
                       </span>
                     )}
+                    lines={4}
+                    tokenize="words"
                   >
                     <div>
                       {campaignDescription}

--- a/src/js/components/Campaign/CampaignCommentForList.jsx
+++ b/src/js/components/Campaign/CampaignCommentForList.jsx
@@ -71,6 +71,12 @@ class CampaignCommentForList extends Component {
     });
   }
 
+  onHideFullSupporterEndorsement = () => {
+    this.setState({
+      showFullSupporterEndorsement: false,
+    });
+  }
+
   onShowFullSupporterEndorsement = () => {
     this.setState({
       showFullSupporterEndorsement: true,
@@ -120,40 +126,30 @@ class CampaignCommentForList extends Component {
                   {showFullSupporterEndorsement ? (
                     <div>
                       <CommentTextInnerWrapper>{supporterEndorsement}</CommentTextInnerWrapper>
-                      {supporterVoterWeVoteId === voterWeVoteId && (
-                        <>
-                          &nbsp;
-                          <Link to={pathToUseToEditSupporterEndorsement}>
-                            edit
-                          </Link>
-                        </>
-                      )}
+                      <div
+                        className="u-cursor--pointer u-link-underline u-link-color--gray"
+                        onClick={this.onHideFullSupporterEndorsement}
+                      >
+                        Read less
+                      </div>
                     </div>
                   ) : (
                     <TruncateMarkup
-                      lines={4}
                       ellipsis={(
-                        <span>
-                          <span className="u-text-fade-at-end">&nbsp;</span>
+                        <div>
                           <span
                             className="u-cursor--pointer u-link-underline u-link-color--gray"
                             onClick={this.onShowFullSupporterEndorsement}
                           >
                             Read more
                           </span>
-                        </span>
+                        </div>
                       )}
+                      lines={4}
+                      tokenize="words"
                     >
                       <div>
-                        <CommentTextInnerWrapper>{supporterEndorsement}</CommentTextInnerWrapper>
-                        {supporterVoterWeVoteId === voterWeVoteId && (
-                          <>
-                            &nbsp;
-                            <Link to={pathToUseToEditSupporterEndorsement}>
-                              edit
-                            </Link>
-                          </>
-                        )}
+                        {supporterEndorsement}
                       </div>
                     </TruncateMarkup>
                   )}
@@ -168,6 +164,14 @@ class CampaignCommentForList extends Component {
                   supported
                   {' '}
                   {timeFromDate(dateSupported)}
+                  {supporterVoterWeVoteId === voterWeVoteId && (
+                    <>
+                      &nbsp;&nbsp;&nbsp;
+                      <Link to={pathToUseToEditSupporterEndorsement}>
+                        Edit
+                      </Link>
+                    </>
+                  )}
                 </CommentNameWrapper>
               </CommentTextWrapper>
             </CommentWrapper>

--- a/src/js/components/Campaign/CampaignCommentsList.jsx
+++ b/src/js/components/Campaign/CampaignCommentsList.jsx
@@ -60,7 +60,8 @@ class CampaignCommentsList extends Component {
   onCampaignSupporterStoreChange () {
     const { campaignXWeVoteId } = this.props;
     // console.log('CampaignCommentsList onCampaignSupporterStoreChange campaignXWeVoteId:', campaignXWeVoteId);
-    const supporterEndorsementsList = CampaignSupporterStore.getCampaignXSupporterEndorsementsList(campaignXWeVoteId);
+    const supporterEndorsementsListUnsorted = CampaignSupporterStore.getCampaignXSupporterEndorsementsList(campaignXWeVoteId);
+    const supporterEndorsementsList = supporterEndorsementsListUnsorted.sort(this.orderByCommentDate);
     this.setState({
       supporterEndorsementsList,
     });
@@ -69,7 +70,8 @@ class CampaignCommentsList extends Component {
   onCampaignStoreChange () {
     const { campaignXWeVoteId } = this.props;
     // console.log('CampaignCommentsList onCampaignStoreChange campaignXWeVoteId:', campaignXWeVoteId);
-    const supporterEndorsementsList = CampaignSupporterStore.getCampaignXSupporterEndorsementsList(campaignXWeVoteId);
+    const supporterEndorsementsListUnsorted = CampaignSupporterStore.getCampaignXSupporterEndorsementsList(campaignXWeVoteId);
+    const supporterEndorsementsList = supporterEndorsementsListUnsorted.sort(this.orderByCommentDate);
     this.setState({
       supporterEndorsementsList,
     });
@@ -82,6 +84,9 @@ class CampaignCommentsList extends Component {
       numberOfCommentsToDisplay,
     });
   }
+
+  // When we have "likes" put comments with most likes at top
+  orderByCommentDate = (firstCampaign, secondCampaign) => secondCampaign.id - firstCampaign.id;
 
   render () {
     renderLog('CampaignCommentsList');  // Set LOG_RENDER_EVENTS to log all renders

--- a/src/js/components/Campaign/CampaignNewsItemForList.jsx
+++ b/src/js/components/Campaign/CampaignNewsItemForList.jsx
@@ -156,7 +156,6 @@ class CampaignNewsItemForList extends Component {
               {campaignNewsText && (
                 <NewsItemTextWrapper className="u-cursor--pointer u-link-color-on-hover" onClick={this.goToDedicatedPublicNewsItemPage}>
                   <TruncateMarkup
-                    lines={4}
                     ellipsis={(
                       <span>
                         <span className="u-text-fade-at-end">&nbsp;</span>
@@ -167,6 +166,8 @@ class CampaignNewsItemForList extends Component {
                         </span>
                       </span>
                     )}
+                    lines={4}
+                    tokenize="words"
                   >
                     <div>
                       {campaignNewsText}

--- a/src/js/components/Campaign/CampaignNewsItemList.jsx
+++ b/src/js/components/Campaign/CampaignNewsItemList.jsx
@@ -41,7 +41,8 @@ class CampaignNewsItemList extends Component {
     } = this.props;
     if (campaignXWeVoteId) {
       if (campaignXWeVoteId !== campaignXWeVoteIdPrevious) {
-        const campaignXNewsItemList = CampaignStore.getCampaignXNewsItemList(campaignXWeVoteId);
+        const campaignXNewsItemListUnsorted = CampaignStore.getCampaignXNewsItemList(campaignXWeVoteId);
+        const campaignXNewsItemList = campaignXNewsItemListUnsorted.sort(this.orderByNewsItemUpdateDate);
         this.setState({
           campaignXNewsItemList,
         });
@@ -56,7 +57,8 @@ class CampaignNewsItemList extends Component {
   onCampaignStoreChange () {
     const { campaignXWeVoteId } = this.props;
     const voterCanSendUpdatesToThisCampaign = CampaignStore.getVoterCanSendUpdatesToThisCampaign(campaignXWeVoteId);
-    const campaignXNewsItemList = CampaignStore.getCampaignXNewsItemList(campaignXWeVoteId);
+    const campaignXNewsItemListUnsorted = CampaignStore.getCampaignXNewsItemList(campaignXWeVoteId);
+    const campaignXNewsItemList = campaignXNewsItemListUnsorted.sort(this.orderByNewsItemUpdateDate);
     this.setState({
       campaignXNewsItemList,
       voterCanSendUpdatesToThisCampaign,
@@ -70,6 +72,8 @@ class CampaignNewsItemList extends Component {
       numberOfNewsItemsToDisplay,
     });
   }
+
+  orderByNewsItemUpdateDate = (firstCampaign, secondCampaign) => new Date(secondCampaign.date_posted) - new Date(firstCampaign.date_posted);
 
   render () {
     renderLog('CampaignNewsItemList');  // Set LOG_RENDER_EVENTS to log all renders

--- a/src/js/components/Campaign/CampaignShareChunk.jsx
+++ b/src/js/components/Campaign/CampaignShareChunk.jsx
@@ -30,19 +30,21 @@ class CampaignShareChunk extends Component {
     if (isCordova()) {
       console.log(`CampaignShareChunk window.location.href: ${window.location.href}`);
     }
-    const { campaignXNewsItemWeVoteId, campaignXWeVoteId, darkButtonsOff } = this.props;
+    const { campaignXNewsItemWeVoteId, campaignXWeVoteId, darkButtonsOff, privatePublicIntroductionsOff } = this.props;
     return (
       <div>
-        <CampaignSupportSectionWrapper>
-          <CampaignSupportSection>
-            <CampaignSupportDesktopButtonWrapper>
-              <CampaignSupportDesktopButtonPanel>
-                <PublicOrPrivateSectionHeader>Share privately. </PublicOrPrivateSectionHeader>
-                <PublicOrPrivateSectionText>
-                  Share 1-on-1 with friends who share your values.
-                </PublicOrPrivateSectionText>
-              </CampaignSupportDesktopButtonPanel>
-            </CampaignSupportDesktopButtonWrapper>
+        <CampaignSupportSectionWrapper marginTopOff={privatePublicIntroductionsOff}>
+          <CampaignSupportSection marginBottomOff={privatePublicIntroductionsOff}>
+            {!privatePublicIntroductionsOff && (
+              <CampaignSupportDesktopButtonWrapper>
+                <CampaignSupportDesktopButtonPanel>
+                  <PublicOrPrivateSectionHeader>Share privately. </PublicOrPrivateSectionHeader>
+                  <PublicOrPrivateSectionText>
+                    Share 1-on-1 with friends who share your values.
+                  </PublicOrPrivateSectionText>
+                </CampaignSupportDesktopButtonPanel>
+              </CampaignSupportDesktopButtonWrapper>
+            )}
             <CampaignSupportDesktopButtonWrapper className="u-show-desktop-tablet">
               <CampaignSupportDesktopButtonPanel>
                 <ShareByEmailButton campaignXNewsItemWeVoteId={campaignXNewsItemWeVoteId} campaignXWeVoteId={campaignXWeVoteId} darkButton={!darkButtonsOff} />
@@ -65,16 +67,18 @@ class CampaignShareChunk extends Component {
             </CampaignSupportMobileButtonWrapper>
           </CampaignSupportSection>
         </CampaignSupportSectionWrapper>
-        <CampaignSupportSectionWrapper>
-          <CampaignSupportSection>
-            <CampaignSupportDesktopButtonWrapper>
-              <CampaignSupportDesktopButtonPanel>
-                <PublicOrPrivateSectionHeader>Share publicly. </PublicOrPrivateSectionHeader>
-                <PublicOrPrivateSectionText>
-                  Share with everyone and make your voice heard.
-                </PublicOrPrivateSectionText>
-              </CampaignSupportDesktopButtonPanel>
-            </CampaignSupportDesktopButtonWrapper>
+        <CampaignSupportSectionWrapper marginTopOff={privatePublicIntroductionsOff}>
+          <CampaignSupportSection marginBottomOff={privatePublicIntroductionsOff}>
+            {!privatePublicIntroductionsOff && (
+              <CampaignSupportDesktopButtonWrapper>
+                <CampaignSupportDesktopButtonPanel>
+                  <PublicOrPrivateSectionHeader>Share publicly. </PublicOrPrivateSectionHeader>
+                  <PublicOrPrivateSectionText>
+                    Share with everyone and make your voice heard.
+                  </PublicOrPrivateSectionText>
+                </CampaignSupportDesktopButtonPanel>
+              </CampaignSupportDesktopButtonWrapper>
+            )}
             <CampaignSupportDesktopButtonWrapper className="u-show-desktop-tablet">
               <CampaignSupportDesktopButtonPanel>
                 <ShareOnFacebookButton campaignXNewsItemWeVoteId={campaignXNewsItemWeVoteId} campaignXWeVoteId={campaignXWeVoteId} darkButton={!darkButtonsOff} />
@@ -105,6 +109,7 @@ CampaignShareChunk.propTypes = {
   campaignXNewsItemWeVoteId: PropTypes.string,
   campaignXWeVoteId: PropTypes.string,
   darkButtonsOff: PropTypes.bool,
+  privatePublicIntroductionsOff: PropTypes.bool,
 };
 
 const PublicOrPrivateSectionHeader = styled.span`

--- a/src/js/components/CampaignSupport/CampaignDetailsActionSideBox.jsx
+++ b/src/js/components/CampaignSupport/CampaignDetailsActionSideBox.jsx
@@ -233,7 +233,11 @@ class CampaignDetailsActionSideBox extends Component {
                   </ButtonPanel>
                 )}
                 <CampaignShareChunkWrapper>
-                  <CampaignShareChunk campaignXWeVoteId={campaignXWeVoteId} darkButtonsOff />
+                  <CampaignShareChunk
+                    campaignXWeVoteId={campaignXWeVoteId}
+                    darkButtonsOff
+                    privatePublicIntroductionsOff
+                  />
                 </CampaignShareChunkWrapper>
               </>
             )}

--- a/src/js/components/Share/ShareByCopyLink.jsx
+++ b/src/js/components/Share/ShareByCopyLink.jsx
@@ -139,7 +139,6 @@ const styles = () => ({
 const Wrapper = styled.div`
   cursor: pointer;
   display: block !important;
-  margin-bottom: 12px;
   @media (min-width: 600px) {
     flex: 1 1 0;
   }

--- a/src/js/components/Style/CampaignSupportStyles.jsx
+++ b/src/js/components/Style/CampaignSupportStyles.jsx
@@ -41,14 +41,14 @@ const CampaignSupportMobileButtonWrapper = styled.div`
 `;
 
 const CampaignSupportSection = styled.div`
-  margin-bottom: 20px !important;
+  ${({ marginBottomOff }) => (marginBottomOff ? '' : 'margin-bottom: 20px !important;')}
   width: 100%;
 `;
 
 const CampaignSupportSectionWrapper = styled.div`
   display: flex;
   justify-content: center;
-  margin-top: 20px;
+  ${({ marginTopOff }) => (marginTopOff ? '' : 'margin-top: 20px;')}
   max-width: 620px;
 `;
 

--- a/src/js/pages/CampaignDetailsPage.jsx
+++ b/src/js/pages/CampaignDetailsPage.jsx
@@ -203,7 +203,7 @@ class CampaignDetailsPage extends Component {
       // If it has changed, use new value
       visibleToPublic = CampaignSupporterStore.getVisibleToPublicQueuedToSave();
     }
-    console.log('functionToUseWhenProfileComplete, blockCampaignXRedirectOnSignIn:', AppStore.blockCampaignXRedirectOnSignIn());
+    // console.log('functionToUseWhenProfileComplete, blockCampaignXRedirectOnSignIn:', AppStore.blockCampaignXRedirectOnSignIn());
     const saveVisibleToPublic = true;
     if (!AppStore.blockCampaignXRedirectOnSignIn()) {
       initializejQuery(() => {

--- a/src/js/pages/CampaignSupport/CampaignRecommendedCampaigns.jsx
+++ b/src/js/pages/CampaignSupport/CampaignRecommendedCampaigns.jsx
@@ -454,13 +454,14 @@ class CampaignRecommendedCampaigns extends Component {
                       />
                     ) : (
                       <TruncateMarkup
-                        lines={3}
                         ellipsis={(
                           <span id="setDescriptionUnfurled" onClick={this.setDescriptionUnfurled}>
                             <span className="u-text-fade-at-end">&nbsp;</span>
                             <span className="u-link-color u-link-underline">Read more</span>
                           </span>
                         )}
+                        lines={3}
+                        tokenize="words"
                       >
                         <div>
                           {recommendedCampaignDescription}


### PR DESCRIPTION
Configured all TruncateMarkup instances to do line breaks at the end of words instead of in the middle. Added "Read less" to mirror "Read more". Sorting news items and comments to show most recent at the top. Removed We Vote logo sharing image, since it takes away from Campaign message.