### PR TITLE
Fix campaigns site

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,9 +80,9 @@ class App extends Component {
         console.log('jQuery loaded since host is not campaigns.wevote.us, firing siteConfigurationRetrieve');
         AppObservableStore.siteConfigurationRetrieve(hostname);
       } else {
-        // Initialize Google Analytics ID with the default value from config.js
-        console.log('jQuery loaded for campaigns.wevote.us, init call to onAppObservableStore');
-        this.onAppObservableStoreChange();
+        // Use default config for campaigns.wevote.us site
+        console.log('jQuery loaded for campaigns.wevote.us, using default settings');
+        AppObservableStore.siteConfigurationUseDefault();
       }
     });
   }

--- a/src/js/common/stores/AppObservableStore.js
+++ b/src/js/common/stores/AppObservableStore.js
@@ -732,6 +732,13 @@ export default {
     return nonFluxState.siteConfigurationHasBeenRetrieved;
   },
 
+  siteConfigurationUseDefault () {
+    nonFluxState.siteConfigurationHasBeenRetrieved = true;
+    nonFluxState.onWeVoteRootUrl = false;
+    nonFluxState.onWeVoteSubdomainUrl = true;
+    messageService.sendMessage('state updated for siteConfigurationUseDefault');
+  },
+
   siteConfigurationRetrieve (hostname, externalVoterId = '', refresh_string = '') {
     $ajax({
       endpoint: 'siteConfigurationRetrieve',

--- a/src/js/common/stores/AppObservableStore.js
+++ b/src/js/common/stores/AppObservableStore.js
@@ -734,7 +734,7 @@ export default {
 
   siteConfigurationUseDefault () {
     nonFluxState.siteConfigurationHasBeenRetrieved = true;
-    nonFluxState.onWeVoteRootUrl = false;
+    nonFluxState.onWeVoteRootUrl = true;
     nonFluxState.onWeVoteSubdomainUrl = true;
     messageService.sendMessage('state updated for siteConfigurationUseDefault');
   },


### PR DESCRIPTION
When the hostname matches "campaigns.wevote.us", we skip loading the config from WeVote API, but some pages check if the config has been loaded.

This change adds a function that sets the flag that config has been loaded, therefore pages render correctly on the main campaigns.wevote.us site.